### PR TITLE
update annotation file

### DIFF
--- a/annotation/DFEW_set_2_test.txt
+++ b/annotation/DFEW_set_2_test.txt
@@ -81,7 +81,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03343 108 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03344 69 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03347 79 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 16 5
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 14 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03351 42 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03352 96 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03353 48 6
@@ -813,7 +813,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04558 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04559 119 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04560 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 16 0
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 11 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04562 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04563 149 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04564 101 2
@@ -2211,7 +2211,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06730 70 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06733 26 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06736 142 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 14 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06746 72 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06750 141 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06754 71 2

--- a/annotation/DFEW_set_2_train.txt
+++ b/annotation/DFEW_set_2_train.txt
@@ -857,7 +857,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01251 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01252 125 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01253 166 5
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01255 85 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01256 83 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01257 72 3
@@ -1040,7 +1040,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01509 60 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01513 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01514 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01516 48 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01517 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01519 48 0
@@ -1175,7 +1175,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01700 53 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01701 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01702 72 1
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01706 160 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01707 51 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01709 96 2
@@ -3387,7 +3387,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08033 29 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08034 125 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08035 47 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 12 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08040 53 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08042 94 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08043 94 4
@@ -3625,7 +3625,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08367 141 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08368 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08371 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08373 55 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08375 96 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08376 60 6
@@ -5404,7 +5404,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10838 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10839 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10841 75 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10843 47 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10844 72 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10845 72 2
@@ -5413,7 +5413,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10849 96 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10850 78 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10852 44 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10856 43 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10857 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10858 121 1
@@ -5808,7 +5808,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11405 59 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11406 150 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11407 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 15 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11409 74 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11410 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11411 63 2
@@ -6727,7 +6727,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12647 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12649 48 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12650 136 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12652 214 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12655 69 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12658 72 6
@@ -7717,7 +7717,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14024 89 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14025 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14026 58 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 13 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14028 36 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14030 60 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14031 84 4
@@ -8000,7 +8000,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14428 71 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14429 100 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14432 24 4
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 15 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14434 70 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14435 120 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14436 71 0

--- a/annotation/DFEW_set_3_test.txt
+++ b/annotation/DFEW_set_3_test.txt
@@ -1046,7 +1046,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08033 29 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08034 125 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08035 47 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 12 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08040 53 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08042 94 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08043 94 4
@@ -1284,7 +1284,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08367 141 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08368 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08371 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08373 55 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08375 96 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08376 60 6

--- a/annotation/DFEW_set_3_train.txt
+++ b/annotation/DFEW_set_3_train.txt
@@ -857,7 +857,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01251 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01252 125 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01253 166 5
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01255 85 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01256 83 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01257 72 3
@@ -1040,7 +1040,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01509 60 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01513 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01514 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01516 48 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01517 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01519 48 0
@@ -1175,7 +1175,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01700 53 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01701 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01702 72 1
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01706 160 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01707 51 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01709 96 2
@@ -2322,7 +2322,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03344 69 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03346 26 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03347 79 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 16 5
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 14 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03351 42 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03352 96 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03353 48 6
@@ -3154,7 +3154,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04558 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04559 119 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04560 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 16 0
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 11 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04562 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04563 149 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04564 101 2
@@ -4552,7 +4552,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06730 70 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06733 26 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06736 142 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 14 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06746 72 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06750 141 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06754 71 2
@@ -5405,7 +5405,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10838 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10839 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10841 75 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10843 47 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10844 72 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10845 72 2
@@ -5414,7 +5414,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10849 96 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10850 78 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10852 44 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10856 43 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10857 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10858 121 1
@@ -5809,7 +5809,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11405 59 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11406 150 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11407 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 15 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11409 74 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11410 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11411 63 2
@@ -6728,7 +6728,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12647 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12649 48 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12650 136 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12652 214 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12655 69 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12658 72 6
@@ -7718,7 +7718,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14024 89 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14025 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14026 58 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 13 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14028 36 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14030 60 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14031 84 4
@@ -8001,7 +8001,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14428 71 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14429 100 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14432 24 4
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 15 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14434 70 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14435 120 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14436 71 0

--- a/annotation/DFEW_set_4_test.txt
+++ b/annotation/DFEW_set_4_test.txt
@@ -723,7 +723,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10838 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10839 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10841 75 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10843 47 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10844 72 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10845 72 2
@@ -732,7 +732,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10849 96 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10850 78 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10852 44 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10856 43 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10857 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10858 121 1
@@ -1127,7 +1127,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11405 59 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11406 150 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11407 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 15 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11409 74 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11410 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11411 63 2
@@ -2039,7 +2039,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12647 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12649 48 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12650 136 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12655 69 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12659 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12662 48 3

--- a/annotation/DFEW_set_4_train.txt
+++ b/annotation/DFEW_set_4_train.txt
@@ -857,7 +857,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01251 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01252 125 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01253 166 5
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01255 85 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01256 83 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01257 72 3
@@ -1040,7 +1040,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01509 60 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01513 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01514 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01516 48 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01517 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01519 48 0
@@ -1175,7 +1175,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01700 53 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01701 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01702 72 1
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01706 160 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01707 51 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01709 96 2
@@ -2322,7 +2322,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03344 69 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03346 26 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03347 79 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 16 5
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 14 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03351 42 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03352 96 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03353 48 6
@@ -3154,7 +3154,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04558 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04559 119 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04560 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 16 0
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 11 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04562 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04563 149 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04564 101 2
@@ -4777,7 +4777,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06731 71 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06733 26 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06736 142 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 14 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06738 148 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06741 58 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06742 50 0
@@ -5728,7 +5728,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08033 29 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08034 125 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08035 47 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 12 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08040 53 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08042 94 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08043 94 4
@@ -5966,7 +5966,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08367 141 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08368 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08371 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08373 55 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08375 96 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08376 60 6
@@ -7719,7 +7719,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14024 89 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14025 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14026 58 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 13 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14028 36 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14030 60 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14031 84 4
@@ -8002,7 +8002,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14428 71 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14429 100 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14432 24 4
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 15 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14434 70 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14435 120 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14436 71 0

--- a/annotation/DFEW_set_5_test.txt
+++ b/annotation/DFEW_set_5_test.txt
@@ -697,7 +697,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14024 89 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14025 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14026 58 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14027 13 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14028 36 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14030 60 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14031 84 4
@@ -980,7 +980,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14428 71 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14429 100 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14432 24 4
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14433 15 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14434 70 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14435 120 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/14436 71 0

--- a/annotation/DFEW_set_5_train.txt
+++ b/annotation/DFEW_set_5_train.txt
@@ -857,7 +857,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01251 143 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01252 125 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01253 166 5
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01254 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01255 85 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01256 83 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01257 72 3
@@ -1040,7 +1040,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01509 60 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01513 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01514 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01515 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01516 48 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01517 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01519 48 0
@@ -1175,7 +1175,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01700 53 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01701 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01702 72 1
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01705 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01706 160 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01707 51 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/01709 96 2
@@ -2322,7 +2322,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03344 69 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03346 26 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03347 79 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 16 5
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03349 14 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03351 42 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03352 96 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/03353 48 6
@@ -3154,7 +3154,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04558 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04559 119 5
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04560 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 16 0
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04561 11 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04562 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04563 149 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/04564 101 2
@@ -4777,7 +4777,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06731 71 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06733 26 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06736 142 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 16 2
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06737 14 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06738 148 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06741 58 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/06742 50 0
@@ -5728,7 +5728,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08033 29 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08034 125 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08035 47 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08038 12 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08040 53 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08042 94 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08043 94 4
@@ -5966,7 +5966,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08367 141 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08368 95 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08371 48 2
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08372 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08373 55 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08375 96 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/08376 60 6
@@ -7745,7 +7745,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10838 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10839 48 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10841 75 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10842 15 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10843 47 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10844 72 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10845 72 2
@@ -7754,7 +7754,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10849 96 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10850 78 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10852 44 0
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 16 6
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10855 14 6
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10856 43 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10857 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/10858 121 1
@@ -8149,7 +8149,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11405 59 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11406 150 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11407 72 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 16 4
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11408 15 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11409 74 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11410 72 0
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/11411 63 2
@@ -9061,7 +9061,7 @@
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12647 71 2
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12649 48 1
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12650 136 3
-/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 16 3
+/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12651 12 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12655 69 4
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12659 48 3
 /data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face/12662 48 3

--- a/annotation/preprocess_annotation.py
+++ b/annotation/preprocess_annotation.py
@@ -1,0 +1,31 @@
+import os
+import pandas as pd
+from glob import glob
+
+DFEW_SOURCE = "/home/zonepg/datasets/DFEW"
+DFEW_CLIP_SOURCE = os.path.join(DFEW_SOURCE, "Clip", "clip_224x224")
+
+def main():
+    all_anno_file = sorted(glob(os.path.join(DFEW_SOURCE, "EmoLabel_DataSplit", "**", "*.csv")))
+    for anno_file in all_anno_file:
+        print(anno_file)
+        data = pd.read_csv(anno_file)
+        write_data = []
+        write_file_path = "DFEW_{}_{}.txt".format(anno_file.split("/")[-1].split(".")[0], anno_file.split("/")[-2])
+        write_file_path = os.path.join("annotation", write_file_path)
+        for index, row in data.iterrows():
+            video_name = str(row["video_name"]).zfill(5)
+            full_video_name = os.path.join("/data/EECS-IoannisLab/datasets/DFEW/DFEW_Frame_Face", video_name)
+            label = str(row["label"] - 1)
+            clip_folder_path = os.path.join(DFEW_SOURCE, "Clip", "clip_224x224", video_name)
+            clip_image_path = sorted(glob(os.path.join(clip_folder_path, "*.jpg")))
+            frame_num = len(clip_image_path)
+            write_data.append("{} {} {}\n".format(full_video_name, frame_num, label))
+        with open(write_file_path, "w") as f:
+            f.writelines(write_data)
+
+
+
+
+if __name__ == "__main__":
+    main()

--- a/dataloader/video_dataloader.py
+++ b/dataloader/video_dataloader.py
@@ -55,7 +55,7 @@ class VideoDataset(data.Dataset):
         elif record.num_frames > self.num_segments:
             offsets = np.sort(randint(record.num_frames - self.duration + 1, size=self.num_segments))
         else:
-            offsets = np.zeros((self.num_segments,))
+            offsets = np.pad(np.array(list(range(record.num_frames))), (0, self.num_segments - record.num_frames), 'edge')
         return offsets
 
     def _get_test_indices(self, record):
@@ -66,7 +66,7 @@ class VideoDataset(data.Dataset):
             tick = (record.num_frames - self.duration + 1) / float(self.num_segments)
             offsets = np.array([int(tick / 2.0 + tick * x) for x in range(self.num_segments)])
         else:
-            offsets = np.zeros((self.num_segments,))
+            offsets = np.pad(np.array(list(range(record.num_frames))), (0, self.num_segments - record.num_frames), 'edge')
         return offsets
 
     def __getitem__(self, index):


### PR DESCRIPTION
hi, thanks for your awesome work!

I'm not sure if the image frames from the DFEW dataset you're using are original frames or manually cut frames from video. 

When I attempted to replicate the code using the official original clip_224x224 path for image frames, I noticed an issue with the **frame_num** in the annotation file. Specifically, the number of some frames in that path should not exceed 16, but it is annotated as 16. This may cause some problems when running the code. If you run my `preprocess_annotation.py` code, you can see that I have made modifications to the annotation file to address this issue.

